### PR TITLE
#171749300 Refactor mark all notifications as read

### DIFF
--- a/locales/en.js
+++ b/locales/en.js
@@ -125,5 +125,8 @@
 	"StopsMustBeArray":"Provide stops",
 	"AccommodationNotFound":"Accommodation not found!!",
 	"ThankFeedback":"Thank you for the feedback",
-	"InvalidParamsRequestId": "Please provide a valid Id"
+	"InvalidParamsRequestId": "Please provide a valid Id",
+	"noUnread": "You currently have no unread notifications",
+	"allmarkedAsRead": "all your unread notifications was marked as read"
 }
+

--- a/locales/en.json
+++ b/locales/en.json
@@ -125,5 +125,8 @@
 	"StopsMustBeArray":"Provide stops",
 	"AccommodationNotFound":"Accommodation not found!!",
 	"ThankFeedback":"Thank you for the feedback",
-	"InvalidParamsRequestId": "Please provide a valid Id"
+	"InvalidParamsRequestId": "Please provide a valid Id",
+	"noUnread": "You currently have no unread notifications",
+	"allmarkedAsRead": "all your unread notifications was marked as read"
 }
+

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -123,5 +123,7 @@
     "StopsMustBeArray":"Fournir des arrêts",
     "AccommodationNotFound":"Logement introuvable !!",
     "ThankFeedback":"Merci pour votre retour",
-    "InvalidParamsRequestId": "Veuillez fournir un identifiant valide"
+    "InvalidParamsRequestId": "Veuillez fournir un identifiant valide",
+    "noUnread": "Vous n'avez actuellement aucune notification non lue",
+    "allmarkedAsRead": "toutes vos notifications non lues ont été marquées comme lues"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -123,5 +123,7 @@
     "StopsMustBeArray":"Fournir des arrêts",
     "AccommodationNotFound":"Logement introuvable !!",
     "ThankFeedback":"Merci pour votre retour",
-    "InvalidParamsRequestId": "Veuillez fournir un identifiant valide"
+    "InvalidParamsRequestId": "Veuillez fournir un identifiant valide",
+    "noUnread": "Vous n'avez actuellement aucune notification non lue",
+    "allmarkedAsRead": "toutes vos notifications non lues ont été marquées comme lues"
 }

--- a/src/controllers/notification.js
+++ b/src/controllers/notification.js
@@ -1,6 +1,7 @@
   
 /* eslint-disable valid-jsdoc */
 /* eslint-disable require-jsdoc */
+import { successResponse, errorResponse } from 'utils/responses';
 import { emailTripRequest } from '../utils/emailHelper';
 import Models from '../database/models';
 import { onlineClients } from '../utils/socket';
@@ -216,6 +217,25 @@ class notificationsController {
         status: 500,
         error: req.i18n.__('internalServerError')
       });
+    }
+  }
+
+  /**
+   * @description This method is used to mark all notifications as read
+   * @param {object} req
+   * @param {object} res
+   */
+  static async markAllNotificationAsRead(req, res) {
+    try {
+      const { id, preferedLang } = req.user;
+
+      await Models.Notification.update({
+        isRead: true
+      }, { where: { receiver: id } });
+
+      return successResponse(res, 200, setLanguage(preferedLang).__('allmarkedAsRead'));
+    } catch (error) {
+      return errorResponse(res, 500, error.message);
     }
   }
 }

--- a/src/database/seeders/20200211104634-dummy-notifications.js
+++ b/src/database/seeders/20200211104634-dummy-notifications.js
@@ -9,6 +9,16 @@ export default {
       isRead: false,
       createdAt: new Date(),
       updatedAt: new Date()
+    },
+    {
+      id: '2',
+      receiver: '0e11ed8c-a1a5-4f49-a3ca-450732bfa49o',
+      requestID: 'fcbb500e-bbf1-479f-92ea-bb29fb0d28c8',
+      type: 'trip request',
+      body: 'Rusimbi made a trip request: - From RW - Kigalig to UG - Kampala. Reason: for some reason',
+      isRead: false,
+      createdAt: new Date(),
+      updatedAt: new Date()
     }
   ]),
   down: (queryInterface) => queryInterface.bulkDelete('Notifications', null, {})

--- a/src/middlewares/unreadNotifications.js
+++ b/src/middlewares/unreadNotifications.js
@@ -1,0 +1,16 @@
+import { errorResponse } from 'utils/responses';
+import Models from 'database/models';
+import setLanguage from 'utils/international';
+
+const haveUnread = async (req, res, next) => {
+  const { id, preferedLang } = req.user;
+  const unread = await Models.Notification.findAll({ where: { receiver: id, isRead: false } });
+
+  if (unread.length === 0) {
+    return errorResponse(res, 404, setLanguage(preferedLang).__('noUnread'));
+  }
+
+  next();
+};
+
+export default haveUnread;

--- a/src/routes/api/notification.routes.js
+++ b/src/routes/api/notification.routes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import checkUser from 'middlewares/checkUser';
 import validation from 'validation/user.validation';
+import haveUnread from 'middlewares/unreadNotifications';
 import notificationController from '../../controllers/notification';
 
 const {
@@ -90,5 +91,21 @@ router.get('/', checkUser, notificationController.getAllNotifications);
  *         description: get unread notifications
  *  */
 router.get('/unread', checkUser, notificationController.unReadNotifications);
+
+/**
+ * @swagger
+ *
+ * /api/v1/notifications/readAll:
+ *   put:
+ *     security: []
+ *     summary: mark all notifications as read
+ *     description: Users can mark all unread notifications as read
+ *     tags:
+ *       - Notifications
+ *     responses:
+ *       200:
+ *         description: all your unread notifications was marked as read
+ *  */
+router.put('/readAll', [checkUser, haveUnread], notificationController.markAllNotificationAsRead);
 
 export default router;

--- a/src/tests/markAsRead.test.js
+++ b/src/tests/markAsRead.test.js
@@ -1,0 +1,33 @@
+import Chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+
+Chai.use(chaiHttp);
+Chai.should();
+
+describe('Barefoot nomad should allow marking all notifications as read', () => {
+  it('It should login successfuly', (done) => {
+    Chai
+      .request(app)
+      .post('/api/v1/auth/signin')
+      .send({
+        email: 'blaisefr@gmail.com',
+        password: 'password',
+      })
+      .end((err, res) => {
+        res.body.should.have.status(200);
+        done();
+      });
+  });
+
+  it('It should mark all unread notifications as read', (done) => {
+    Chai
+      .request(app)
+      .put('/api/v1/notifications/readAll')
+      .end((err, res) => {
+        res.body.should.have.status(200);
+        res.body.should.have.property('message', 'all your unread notifications was marked as read');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

- create an endpoint that will mark all user's notifications as read

### How should this be manually tested?

- clone this repo by running this command in your terminal `git clone <repo name>`.
- switch to this branch `ch-refactor-mark-notificationAsRead-171749300` by running `git checkout <branch name>` in your terminal.
- referencing *.env.example* create a *.env* file and add all required variables.
- run `npm i` in your terminal to install all project dependencies.
- run `npm run migrateDb` in your terminal to migrate the database.
- run `npm run dev` in your terminal to start the development server.
- using postman, login to the system using this route *POST* `http://localhost:3000/api/v1/auth/signin` *you will need to provide email and password*.
- after login, use this route *PUT* `http://localhost:3000/api/v1/notifications/readAll` to mark all your unread notifications as read.
### Implementation plan

[Implementation plan](https://markAll.com)

### Stories associated with PR

[#171749300](https://www.pivotaltracker.com/story/show/171749300)

### Screenshots if any
<img width="1141" alt="Screen Shot 2020-03-10 at 23 04 45" src="https://user-images.githubusercontent.com/53453380/76359264-98654400-6323-11ea-8881-0b2ef5ae125a.png">
<img width="1133" alt="Screen Shot 2020-03-10 at 23 03 43" src="https://user-images.githubusercontent.com/53453380/76359272-9d29f800-6323-11ea-92f8-3238b8cfa93c.png">
